### PR TITLE
fix: Keep original order

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_networkfirewall_firewall" "this" {
   subnet_change_protection          = var.subnet_change_protection
 
   dynamic "subnet_mapping" {
-    for_each = toset(var.subnet_mapping)
+    for_each = var.subnet_mapping
 
     content {
       subnet_id = subnet_mapping.value


### PR DESCRIPTION
In the follow scenario, We want to add a route to intra route table point to network firewall endpoint in the same AZ. the order is not matched with function `toset()`.  Then we got a miss match, and original order is keeped after remove `toset()`.


``` terraform
locals {
  name   = "test-nfw"
  region = "eu-west-2"
  azs    = ["${local.region}a", "${local.region}b", "${local.region}c"]
}

module "network_firewall" {
  source        = "mattyait/network-firewall/aws"

  firewall_name = "egress-network-firewall"
  vpc_id        = module.central_egress_vpc.vpc_id
  prefix        = "fw-egress"

  subnet_mapping = module.central_egress_vpc.private_subnets
  #Domain Firewall Rule Group
  domain_stateful_rule_group = [ 
       # xxx
  ]

  stateless_rule_group = []

  tags = {
    Name        = "example"
    Environment = "test"
    Created_By  = "Terraform"
  }

  depends_on = [module.central_egress_vpc]
}

resource "aws_route" "central_egress_tgw" {
  count = length(module.central_egress_vpc.intra_route_table_ids)

  route_table_id         = element(module.central_egress_vpc.intra_route_table_ids[*], count.index)
  destination_cidr_block = "0.0.0.0/0"
  vpc_endpoint_id        = element(module.network_firewall.endpoint_id[*], count.index)

  depends_on = [module.central_egress_vpc, module.network_firewall]
}

module "central_egress_vpc" {
  source = "terraform-aws-modules/vpc/aws"


  name = "central-egress-vpc"
  cidr = "10.10.0.0/16"

  azs = local.azs

  # public
  public_subnets = ["10.10.31.0/24", "10.10.32.0/24", "10.10.33.0/24"]
  intra_subnets   = ["10.10.0.0/28", "10.10.0.16/28", "10.10.0.32/28"]
  private_subnets = ["10.10.1.0/28", "10.10.1.16/28", "10.10.1.32/28"]

  public_subnet_suffix  = "nat-subnet"
  private_subnet_suffix = "fw-subnet" 
  intra_subnet_suffix   = "tgw-subnet"

  enable_nat_gateway = true

}
```
 