### PR TITLE
fix: Fix version pinning that is too specific

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50.0"
+      version = "~> 4.50"
     }
   }
 }


### PR DESCRIPTION
The version constraint for the AWS provider in this repository is too specific and is only compatible with version 4.50.x (https://developer.hashicorp.com/terraform/language/expressions/version-constraints#-3). This conflicts with pretty much any other module that specifies an AWS provider version (such as needing features from newer AWS provider releases). 

This PR fixes the version constraint so that it can be used with newer AWS provider versions (any 4.x version instead of any 4.50.x version).